### PR TITLE
fix styling on coc links

### DIFF
--- a/_data/coc.yaml
+++ b/_data/coc.yaml
@@ -5,8 +5,8 @@ es:
 
     La organización velará por su cumplimiento durante toda la jornada y esperamos la colaboración de todos los participantes para mantener un ambiente respetuoso e inclusivo.
 
-    En caso de que sea necesario reportar una violación del código de conducta, podéis contactar con VLCTechFest (<a style="color:#ffffff" href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>).
-  help: ¿Necesitas ayuda? Tienes nuestros datos de contacto en la parte inferior de esta página. Podéis contactar con VLCTechFest en (<a style="color:#ffffff" href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>).
+    En caso de que sea necesario reportar una violación del código de conducta, podéis contactar con VLCTechFest en <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
+  help: ¿Necesitas ayuda? Tienes nuestros datos de contacto en la parte inferior de esta página. Podéis contactar con VLCTechFest en <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
 
   resume: Sé respetuoso con todo el mundo
   link:
@@ -35,8 +35,8 @@ en:
     
     The organisation will ensure compliance throughout the day and we expect everyone to work together to maintain a respectful and inclusive environment.
     
-    In case it is necessary to report a violation of the code of conduct, you can get in contact with VLCTechFest (<a style="color:#ffffff" href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>).
-  help: Do you need help? Our contact details are at the bottom of this page. You can get in contact with VLCTechFest at (<a style="color:#ffffff" href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>).
+    In case it is necessary to report a violation of the code of conduct, you can get in contact with VLCTechFest <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
+  help: Do you need help? Our contact details are at the bottom of this page. You can get in contact with VLCTechFest at <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
 
   resume: Be respectful to everyone
   link:
@@ -65,8 +65,8 @@ ca:
     
     L'organització vetlarà pel seu compliment durant tota la jornada i esperem la col·laboració de tots els participants per a mantindre un ambient respectuós i inclusiu.
     
-    En el cas que siga necessari reportar una violació del codi de conducta, podeu contactar amb VLCTechFest (<a style="color:#ffffff" href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>).
-  help: Necessites ajuda? Tens les nostres dades de contacte a la part inferior d'aquesta pàgina. Podeu contactar amb VLCTechFest a (<a style="color:#ffffff" href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>).
+    En el cas que siga necessari reportar una violació del codi de conducta, podeu contactar amb VLCTechFest <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
+  help: Necessites ajuda? Tens les nostres dades de contacte a la part inferior d'aquesta pàgina. Podeu contactar amb VLCTechFest a <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
   resume: Sigues respectuós amb tothom
   link:
     text: Llig el Codi de Conducta

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -574,6 +574,10 @@ body {
   --secondaryColor: var(--blue);
   --secondaryTextColor: var(--white);
 }
+.section-pink a:not(.button) {
+  color: var(--white);
+  font-weight: 400;
+}
 
 .section-main {
   padding-top: 0;


### PR DESCRIPTION
El problema era que estabamos pintando los links del COC con un texto blanco, sin embargo en la version larga del COC el fondo es tambien blanco, haciendolos invisibles.

Para solucionarlo, he añadido una propiedad de css a los links que estan sobre un fondo rosa para que se vean en blanco, dejando el resto de links con el color por defecto.

Para los casos en los que el texto y el link son blancos, he añadido el efecto de **negrita** para que resaltar los enlaces.

**BUG**
![css-link-before](https://github.com/user-attachments/assets/3bcec9c5-7d9f-4d29-a7ac-db0cdc8d5314)

**FIX**
![css-link-after](https://github.com/user-attachments/assets/513f0afc-2860-45e5-87c3-922dd106f33f)
