### PR TITLE
Add registration link for workshops

### DIFF
--- a/_data/workshops.yaml
+++ b/_data/workshops.yaml
@@ -20,6 +20,7 @@
 - startTime: "9:30"
   endTime: "11:30"
   room: Patio
+  registrationLink: "https://www.meetup.com/vlctechhub/events/307868179/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link"
   title: "Taller de soldadura Junior: ¡Suelda tu propia Badge!"
   description: |-
     Vive una experiencia única combinando tecnología, creatividad y aprendizaje práctico. El taller está diseñado para todos los niveles y es completamente gratuito para todos los participantes. Os guiaremos paso a paso en el mundo de la electrónica a través del montaje de una badge personalizada.
@@ -35,8 +36,6 @@
     Si al final no puedes venir, indícanoslo para liberar la plaza para otra persona.
 
     No dudéis en preguntar cualquier duda que os surja.
-
-    <a href="https://www.meetup.com/vlctechhub/events/307868179/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link">¡Inscríbete!</a>
 
 - startTime: "12:00"
   endTime: "14:00"
@@ -57,6 +56,7 @@
 - startTime: "12:00"
   endTime: "14:00"
   room: Patio
+  registrationLink: "https://www.meetup.com/vlctechhub/events/307862702/?utm_medium=referral&utm_campaign=share-btn_savedevents_share_modal&utm_source=link"
   title: "Taller de soldadura"
   description: |-
          De la mano del Hackerspace, os proponemos de nuevo ponernos manos a la obra: Aprende a soldar montando una placa funcional y... ¡al terminar podrás llevártela!
@@ -74,6 +74,7 @@
 - startTime: "16:00"
   endTime: "18:00"
   room: Sala Collab
+  registrationLink: ""
   title: "JavaScript for the Rest of Us"
   description: |-
     Aprender JavaScript puede parecer abrumador, pero la base sigue siendo simple y poderosa.

--- a/_includes/sections/workshops.html
+++ b/_includes/sections/workshops.html
@@ -24,6 +24,9 @@
             {%- endfor -%}
           </ul>
           <p class="room">Sala: <span>{{session.room}}</span></p>
+          {% if session.registrationLink | strip_newlines != "" %}
+          <p class="registration-link"><a href="{{session.registrationLink}}">🎫 Apúntate aquí</a></p>
+          {%- endif -%}
           <span class="chevron">{%- include chevron-down.svg -%}</span>
           <div class="description">{{session.description | markdownify }}</div>
           <span class="chevron-bottom hide">{%- include chevron-down.svg -%}</span>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -1273,3 +1273,8 @@ $card-shadow: 0 6px 10px rgba(0, 0, 0, 0.125);
     }
   }
 }
+
+.registration-link {
+  margin-top: 0.5em;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
Workshops requiring prior registration will show its registration link in the card when assigning the `registrationLink` tag to the session data.

Desktop:
<img width="1045" height="746" alt="image" src="https://github.com/user-attachments/assets/d07f5fb6-ccf2-4d54-8ccc-786b111584f9" />

Mobile:
<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/9dbf29c4-add9-4407-bcc5-a728e109e59c" />
