### PR TITLE
Cambios en el Código de conducta para 2026

### DIFF
--- a/_data/coc.yaml
+++ b/_data/coc.yaml
@@ -1,88 +1,109 @@
 es:
   title: Código de Conducta
   notice: |-
-    En VLCTechFest queremos garantizar un entorno seguro y acogedor para todos los asistentes, ponentes, patrocinadores, colaboradores y voluntarios. Por ello, la participación en el evento implica la aceptación y cumplimiento de nuestro código de conducta.
+    En VLCTechFest queremos garantizar un entorno seguro y acogedor para todas las personas que asistan. Al participar en el evento aceptas y te comprometes a cumplir este código de conducta.
 
-    La organización velará por su cumplimiento durante toda la jornada y esperamos la colaboración de todos los participantes para mantener un ambiente respetuoso e inclusivo.
+    La organización velará por su cumplimiento durante toda la jornada y esperamos la colaboración de todas las personas para mantener un ambiente respetuoso e inclusivo.
 
-    En caso de que sea necesario reportar una violación del código de conducta, podéis contactar con VLCTechFest en <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
-  help: ¿Necesitas ayuda? Tienes nuestros datos de contacto en la parte inferior de esta página. Podéis contactar con VLCTechFest en <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
+  help: ¿Necesitas ayuda o quieres reportar un incidente? <strong>Habla con cualquier persona de la organización</strong> (camiseta) o escríbenos a <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>. Si hay riesgo inmediato, contacta con seguridad del recinto o con emergencias.
 
   resume: Sé respetuoso con todo el mundo
   link:
     text: Lee el Código de Conducta
     relative_path: code_of_conduct.html
-  short: Nuestra conferencia quiere proporcionar una experiencia libre de acoso para todo el mundo, independientemente del sexo, identidad y expresión de género, edad, orientación sexual, discapacidad, apariencia física, tamaño corporal, raza, etnia, religión (o carencia de ella) u opciones tecnológicas. No toleramos el acoso de los participantes de la conferencia de ninguna forma. El lenguaje y las imágenes de carácter sexual no son apropiadas para ningún espacio de la conferencia, incluidas charlas, talleres, fiestas o medios de comunicación en línea. Los participantes de la conferencia que violen estas reglas pueden ser amonestados o expulsados de la conferencia a discreción de la organización.
+
+  short: Nuestra conferencia quiere proporcionar una experiencia libre de acoso para todo el mundo, independientemente del sexo, identidad o expresión de género, edad, orientación sexual, discapacidad, apariencia física, tamaño corporal, raza, etnia, religión (o ausencia de ella) u opciones tecnológicas. No toleramos el acoso en ninguna forma. El lenguaje y las imágenes de carácter sexual no son apropiados en ningún espacio del evento.
+
   long: |-
-    El acoso incluye (aunque no está limitado a) comentarios verbales ofensivos relacionados con género, identidad y expresión de género, edad, orientación sexual, discapacidad, apariencia física, tamaño corporal, raza, etnia, religión u opciones tecnológicas; imágenes de carácter sexual en espacios públicos, intimidación, persecución, seguimiento, fotografías o grabaciones no deseadas, interrupción sostenida de charlas u otros acontecimientos, contacto físico inadecuado y atención sexual no deseada.
+    El acoso incluye, entre otros:
 
-    Se espera de los participantes que detengan inmediatamente cualquier comportamiento de acoso cuando se les pida.
+    - Comentarios ofensivos o discriminatorios.
+    - Intimidación, amenazas, persecución o seguimiento.
+    - Contacto físico sin consentimiento.
+    - Atención sexual no deseada.
+    - Fotografías o grabaciones sin permiso.
+    - Interrupciones reiteradas de charlas u otros acontecimientos.
 
-    Los patrocinadores y colaboradores también están sujetos a la política contra el acoso. En particular, los patrocinadores y los colaboradores no han de usar imágenes, actividades o ningún otro material con carácter sexual. El personal presente en la conferencia (incluido el voluntario) no ha de usar ropa/uniformes/disfraces sexualizados ni crear un entorno sexualizado de cualquier otra manera.
+    Si se te pide que detengas un comportamiento, hazlo de inmediato.
 
-    Si cualquier participante incurre en un comportamiento abusivo los organizadores pueden tomar cualquier decisión que consideran oportuna, incluidas la advertencia al ofensor o su expulsión de la conferencia sin derecho a indemnización alguna.
+    Los patrocinadores, colaboradores y personal del evento también están sujetos a esta política y no deben usar contenido sexualizado ni crear un entorno sexualizado.
 
-    Si estás sufriendo acoso, observas que alguien otro está sufriendo acoso o tienes cualquier otra inquietud, pónte en contacto con la organización inmediatamente. Se prodrá identificar fácilmente a los miembros de la organización de la conferencia porque llevarán camisetas o identificaciones del evento.
+    Si una persona incurre en un comportamiento abusivo, la organización podrá tomar las medidas que considere oportunas, incluida una advertencia o la expulsión del evento sin derecho a reembolso.
 
-    Los miembros de la organización estarán encantados de ayudar los participantes de la conferencia a ponerse en contacto con el personal de seguridad o con la policía, a proporcionar acompañamiento y a ayudar a cualquier persona que esté sufriendo de acoso a sentirse segura durante la conferencia. Valoramos tu asistencia por encima de todo.
+    Si estás sufriendo acoso, observas que alguien más lo está sufriendo o tienes cualquier inquietud, ponte en contacto con la organización cuanto antes.
 
-    Esperamos que los participantes cumplan estas normas en todos los espacios relacionados con la conferencia.
+    Estas normas se aplican a todos los espacios relacionados con la conferencia.
+
 
 en:
   title: Code of Conduct
   notice: |-
-    VLCTechFest we want to provide a safe and welcoming environment for all attendees, speakers, sponsors, staff and volunteers. Therefore, participation in the event implies acceptance and adherence to our Code of Conduct.
-    
-    The organisation will ensure compliance throughout the day and we expect everyone to work together to maintain a respectful and inclusive environment.
-    
-    In case it is necessary to report a violation of the code of conduct, you can get in contact with VLCTechFest <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
-  help: Do you need help? Our contact details are at the bottom of this page. You can get in contact with VLCTechFest at <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
+    At VLCTechFest we aim to ensure a safe and welcoming environment for everyone attending. By participating in the event, you agree to comply with this Code of Conduct.
+
+    The organizing team will ensure compliance throughout the event and we expect everyone’s cooperation in maintaining a respectful and inclusive atmosphere.
+
+  help: Need help or want to report an incident? <strong>Talk to any member of the organizing team</strong> (event shirt) or email us at <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>. If there is immediate danger, contact venue security or emergency services.
 
   resume: Be respectful to everyone
   link:
     text: Read the Code of Conduct
     relative_path: code_of_conduct.html
-  short: Our conference is dedicated to providing a harassment-free conference experience for everyone, regardless of gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment of conference participants in any form. Sexual language and imagery is not appropriate for any conference venue, including talks, workshops, parties and online media. Conference participants violating these rules may be sanctioned or expelled from the conference at the discretion of the conference organisers.
+
+  short: Our conference is committed to providing a harassment-free experience for everyone, regardless of sex, gender identity or expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment in any form. Sexual language or imagery is not appropriate in any event space.
+
   long: |-
-    Harassment includes (but is not limited to) offensive verbal comments related to gender, gender identity and expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion or technology choices; sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact and unwelcome sexual attention.
+    Harassment includes, but is not limited to:
 
-    Participants asked to stop any harassing behavior are expected to comply immediately.
+    - Offensive or discriminatory comments.
+    - Intimidation, threats, stalking, or following.
+    - Unwanted physical contact.
+    - Unwanted sexual attention.
+    - Recording or photographing without consent.
+    - Repeated disruption of talks or other activities.
 
-    Sponsors and partners are also subject to the anti-harassment policy. In particular, sponsors and partners should not use sexualised images, activities or other material. Staff present at the conference (including volunteers) should not use sexualised clothing/uniforms/costumes or otherwise create a sexualised environment.
+    If you are asked to stop any behavior, stop immediately.
 
-    If a participant engages in harassing behavior, the conference organisers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no compensation.
+    Sponsors, partners, and event staff are also subject to this policy and must not use sexualized content or create a sexualized environment.
 
-    If you are being harassed, notice that someone else is being harassed or have any other concerns, please contact a member of conference staff immediately. Conference staff can be identified as they'll be wearing branded clothing and/or badges.
+    If a participant engages in abusive behavior, the organizers may take any action they deem appropriate, including a warning or expulsion from the event without refund.
 
-    Conference staff will be happy to help participants contact venue security or local law enforcement, provide escorts or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance.
+    If you are being harassed, notice someone else is being harassed, or have any concerns, contact the organizing team as soon as possible.
 
-    We expect participants to follow these rules at conference venues and conference-related social events.
+    This policy applies to all event-related spaces.
+
 
 ca:
   title: Codi de Conducta
   notice: |-
-    En VLCTechFest volem garantir un entorn segur i acollidor per a tots els assistents, ponents, patrocinadors, col·laboradors i voluntaris. Per això, la participació en l'esdeveniment implica l'acceptació i compliment del nostre codi de conducta.
-    
-    L'organització vetlarà pel seu compliment durant tota la jornada i esperem la col·laboració de tots els participants per a mantindre un ambient respectuós i inclusiu.
-    
-    En el cas que siga necessari reportar una violació del codi de conducta, podeu contactar amb VLCTechFest <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
-  help: Necessites ajuda? Tens les nostres dades de contacte a la part inferior d'aquesta pàgina. Podeu contactar amb VLCTechFest a <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>.
+    En VLCTechFest volem garantir un entorn segur i acollidor per a totes les persones que hi assistisquen. En participar en l’esdeveniment acceptes i et compromets a complir aquest codi de conducta.
+
+    L’organització vetlarà pel seu compliment durant tota la jornada i esperem la col·laboració de tothom per mantenir un ambient respectuós i inclusiu.
+
+  help: Necessites ajuda o vols reportar un incident? <strong>Parla amb qualsevol persona de l’organització</strong> (samarreta) o escriu-nos a <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>. Si hi ha risc immediat, contacta amb seguretat del recinte o amb emergències.
+
   resume: Sigues respectuós amb tothom
   link:
     text: Llig el Codi de Conducta
     relative_path: code_of_conduct.html
-  short: La nostra conferència vol proporcionar una experiència lliure d'assetjament per a tothom, independentment del sexe, identitat i expressió de gènere, edat, orientació sexual, discapacitat, aparença física, grandària corporal, raça, ètnia, religió (o manca d'ella) o opcions tecnològiques. No tolerem l'assetjament dels participants de la conferència de cap manera. El llenguatge i les imatges de caràcter sexual no són apropiades per a cap espai de la conferència, incloses xerrades, tallers, festes o mitjans de comunicació en línia. Els participants de la conferència que violen aquestes regles poden ser amonestats o expulsats de la conferència a discreció de la organització.
+
+  short: La nostra conferència vol proporcionar una experiència lliure d’assetjament per a tothom, independentment del sexe, identitat o expressió de gènere, edat, orientació sexual, discapacitat, aparença física, mida corporal, raça, ètnia, religió (o absència d’ella) o opcions tecnològiques. No tolerem l’assetjament en cap forma. El llenguatge o les imatges de caràcter sexual no són apropiats en cap espai de l’esdeveniment.
+
   long: |-
-    L'assetjament inclou (encara que no està limitat a) comentaris verbals ofensius relacionats amb gènere, identitat i expressió de gènere, edat, orientació sexual, discapacitat, aparença física, grandària corporal, raça, ètnia, religió o opcions tecnològiques; imatges de caràcter sexual en espais públics, intimidació, persecució, seguiment, fotografies o enregistraments no desitjades, interrupció sostinguda de xerrades o altres esdeveniments, contacte físic inadequat i atenció sexual no desitjada.
+    L’assetjament inclou, entre altres:
 
-    S'espera dels participants que aturen immediatament qualsevol comportament d'assetjament quan se'ls demane.
+    - Comentaris ofensius o discriminatoris.
+    - Intimidació, amenaces, persecució o seguiment.
+    - Contacte físic sense consentiment.
+    - Atenció sexual no desitjada.
+    - Fotografies o gravacions sense permís.
+    - Interrupcions reiterades de xarrades o altres activitats.
 
-    Els patrocinadors i col·laboradors també estan subjectes a la política contra l'assetjament. En particular, els patrocinadors i els col·laboradors no han d'usar imatges, activitats o cap altre material amb caràcter sexual. El personal present a la conferència (inclòs el voluntari) no ha d'usar roba/uniforms/disfresses sexualitzats ni crear un entorn sexualitzat de qualsevol altre manera.
+    Si se’t demana que pares un comportament, fes-ho immediatament.
 
-    Si qualsevol participant incorre en un comportament abusiu els organitzadors poden prendre qualsevol decisió que consideren oportuna, incloses l'advertiment al ofensor o la seua expulsió de la conferència sense dret a cap indemnització.
+    Patrocinadors, col·laboradors i personal de l’esdeveniment també estan subjectes a aquesta política i no han d’utilitzar contingut sexualitzat ni crear un entorn sexualitzat.
 
-    Si estàs patint d'assetjament, observes que algú altre està patint d'assetjament o tens qualsevol altra inquietud, posa't en contacte amb la organització immediatament. Es podrà identificar fàcilment als membres de l'organització de la conferència perquè portaran samarretes o identificacions de l'esdeveniment.
+    Si una persona incorre en un comportament abusiu, l’organització podrà prendre les mesures que considere oportunes, incloent-hi un avís o l’expulsió de l’esdeveniment sense dret a reemborsament.
 
-    Els membres de l'organització estaran encantats d'ajudar els participants de la conferència a posar-se en contacte amb el personal de seguretat o amb la policia, a proporcionar-les acompanyament i a ajudar a qualsevol persona que estiga patint d'assetjament a sentir-se segura durant la conferència. Valorem la teua assistència per damunt de tot.
+    Si estàs patint assetjament, veus que una altra persona n’està patint o tens qualsevol inquietud, contacta amb l’organització com més prompte millor.
 
-    Esperem que els participants compleixen aquestes normes en tots els espais relacionats amb la conferència.
+    Aquesta política s’aplica a tots els espais relacionats amb la conferència.

--- a/_data/coc.yaml
+++ b/_data/coc.yaml
@@ -3,16 +3,16 @@ es:
   notice: |-
     En VLCTechFest queremos garantizar un entorno seguro y acogedor para todas las personas que asistan. Al participar en el evento aceptas y te comprometes a cumplir este código de conducta.
 
-    La organización velará por su cumplimiento durante toda la jornada y esperamos la colaboración de todas las personas para mantener un ambiente respetuoso e inclusivo.
+    La organización velará por su cumplimiento durante toda la jornada y esperamos la colaboración de todas las personas para mantener un ambiente respetuoso, inclusivo y sostenible.
 
-  help: ¿Necesitas ayuda o quieres reportar un incidente? <strong>Habla con cualquier persona de la organización</strong> (camiseta) o escríbenos a <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>. Si hay riesgo inmediato, contacta con seguridad del recinto o con emergencias.
+  help: ¿Necesitas ayuda o quieres reportar un incidente? <strong>Habla con cualquier persona de la organización</strong>, que podrás identificar fácilmente por la camiseta oficial del evento, o escríbenos a <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>. Si hay riesgo inmediato, contacta con seguridad del recinto o con emergencias.
 
   resume: Sé respetuoso con todo el mundo
   link:
     text: Lee el Código de Conducta
     relative_path: code_of_conduct.html
 
-  short: Nuestra conferencia quiere proporcionar una experiencia libre de acoso para todo el mundo, independientemente del sexo, identidad o expresión de género, edad, orientación sexual, discapacidad, apariencia física, tamaño corporal, raza, etnia, religión (o ausencia de ella) u opciones tecnológicas. No toleramos el acoso en ninguna forma. El lenguaje y las imágenes de carácter sexual no son apropiados en ningún espacio del evento.
+  short: Nuestra conferencia quiere proporcionar una experiencia libre de acoso para todas las personas.
 
   long: |-
     El acoso incluye, entre otros:
@@ -24,11 +24,7 @@ es:
     - Fotografías o grabaciones sin permiso.
     - Interrupciones reiteradas de charlas u otros acontecimientos.
 
-    Si se te pide que detengas un comportamiento, hazlo de inmediato.
-
-    Los patrocinadores, colaboradores y personal del evento también están sujetos a esta política y no deben usar contenido sexualizado ni crear un entorno sexualizado.
-
-    Si una persona incurre en un comportamiento abusivo, la organización podrá tomar las medidas que considere oportunas, incluida una advertencia o la expulsión del evento sin derecho a reembolso.
+    Fomentamos también un comportamiento responsable con el entorno y las instalaciones del recinto. Esperamos que todas las personas asistentes respeten las normas del espacio, hagan un uso adecuado de los recursos y contribuyan a reducir el impacto ambiental del evento.
 
     Si estás sufriendo acoso, observas que alguien más lo está sufriendo o tienes cualquier inquietud, ponte en contacto con la organización cuanto antes.
 
@@ -40,16 +36,16 @@ en:
   notice: |-
     At VLCTechFest we aim to ensure a safe and welcoming environment for everyone attending. By participating in the event, you agree to comply with this Code of Conduct.
 
-    The organizing team will ensure compliance throughout the event and we expect everyone’s cooperation in maintaining a respectful and inclusive atmosphere.
+    The organizing team will ensure compliance throughout the event and we expect everyone’s cooperation in maintaining a respectful, inclusive, and sustainable environment.
 
-  help: Need help or want to report an incident? <strong>Talk to any member of the organizing team</strong> (event shirt) or email us at <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>. If there is immediate danger, contact venue security or emergency services.
+  help: Need help or want to report an incident? <strong>Talk to any member of the organizing team</strong>, who can be easily identified by the official event shirt, or email us at <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>. If there is immediate danger, contact venue security or emergency services.
 
   resume: Be respectful to everyone
   link:
     text: Read the Code of Conduct
     relative_path: code_of_conduct.html
 
-  short: Our conference is committed to providing a harassment-free experience for everyone, regardless of sex, gender identity or expression, age, sexual orientation, disability, physical appearance, body size, race, ethnicity, religion (or lack thereof), or technology choices. We do not tolerate harassment in any form. Sexual language or imagery is not appropriate in any event space.
+  short: Our conference aims to provide a harassment-free experience for everyone.
 
   long: |-
     Harassment includes, but is not limited to:
@@ -61,11 +57,7 @@ en:
     - Recording or photographing without consent.
     - Repeated disruption of talks or other activities.
 
-    If you are asked to stop any behavior, stop immediately.
-
-    Sponsors, partners, and event staff are also subject to this policy and must not use sexualized content or create a sexualized environment.
-
-    If a participant engages in abusive behavior, the organizers may take any action they deem appropriate, including a warning or expulsion from the event without refund.
+    We also promote responsible behavior toward the venue and its facilities. All attendees are expected to respect the space, use resources responsibly, and help reduce the environmental impact of the event.
 
     If you are being harassed, notice someone else is being harassed, or have any concerns, contact the organizing team as soon as possible.
 
@@ -77,16 +69,16 @@ ca:
   notice: |-
     En VLCTechFest volem garantir un entorn segur i acollidor per a totes les persones que hi assistisquen. En participar en l’esdeveniment acceptes i et compromets a complir aquest codi de conducta.
 
-    L’organització vetlarà pel seu compliment durant tota la jornada i esperem la col·laboració de tothom per mantenir un ambient respectuós i inclusiu.
+    L’organització vetlarà pel seu compliment durant tota la jornada i esperem la col·laboració de tothom per mantenir un ambient respectuós, inclusiu i sostenible.
 
-  help: Necessites ajuda o vols reportar un incident? <strong>Parla amb qualsevol persona de l’organització</strong> (samarreta) o escriu-nos a <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>. Si hi ha risc immediat, contacta amb seguretat del recinte o amb emergències.
+  help: Necessites ajuda o vols reportar un incident? <strong>Parla amb qualsevol persona de l’organització</strong>, que podràs identificar fàcilment per la samarreta oficial de l’esdeveniment, o escriu-nos a <a href="mailto:vlctechfest@gmail.com">vlctechfest@gmail.com</a>. Si hi ha risc immediat, contacta amb seguretat del recinte o amb emergències.
 
   resume: Sigues respectuós amb tothom
   link:
     text: Llig el Codi de Conducta
     relative_path: code_of_conduct.html
 
-  short: La nostra conferència vol proporcionar una experiència lliure d’assetjament per a tothom, independentment del sexe, identitat o expressió de gènere, edat, orientació sexual, discapacitat, aparença física, mida corporal, raça, ètnia, religió (o absència d’ella) o opcions tecnològiques. No tolerem l’assetjament en cap forma. El llenguatge o les imatges de caràcter sexual no són apropiats en cap espai de l’esdeveniment.
+  short: La nostra conferència vol proporcionar una experiència lliure d’assetjament per a totes les persones.
 
   long: |-
     L’assetjament inclou, entre altres:
@@ -98,11 +90,7 @@ ca:
     - Fotografies o gravacions sense permís.
     - Interrupcions reiterades de xarrades o altres activitats.
 
-    Si se’t demana que pares un comportament, fes-ho immediatament.
-
-    Patrocinadors, col·laboradors i personal de l’esdeveniment també estan subjectes a aquesta política i no han d’utilitzar contingut sexualitzat ni crear un entorn sexualitzat.
-
-    Si una persona incorre en un comportament abusiu, l’organització podrà prendre les mesures que considere oportunes, incloent-hi un avís o l’expulsió de l’esdeveniment sense dret a reemborsament.
+    També promovem un comportament responsable amb el recinte i les seues instal·lacions. Esperem que totes les persones assistents respecten l’espai, facen un ús adequat dels recursos i contribuïsquen a reduir l’impacte ambiental de l’esdeveniment.
 
     Si estàs patint assetjament, veus que una altra persona n’està patint o tens qualsevol inquietud, contacta amb l’organització com més prompte millor.
 


### PR DESCRIPTION
# ToDo

Actualizar el Código de conducta para la edición de 2026

- Corregir faltas de ortografía
- Ser más directo cuando se pida ayuda
- Detallar el tipos de acoso

Así es como queda: 
[Código de conducta.pdf](https://github.com/user-attachments/files/25544106/Codigo.de.conducta.pdf)
